### PR TITLE
Add ToggleTabs component for filter selection in UserIndex

### DIFF
--- a/resources/js/components/toggle-tabs.tsx
+++ b/resources/js/components/toggle-tabs.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import clsx from 'clsx';
+
+interface ToggleTabsProps {
+  tabs: string[];
+  active: string;
+  onChange: (tab: string) => void;
+}
+
+export default function ToggleTabs({ tabs, active, onChange }: ToggleTabsProps) {
+  return (
+    <div className="inline-flex gap-1 rounded-lg bg-neutral-100 p-1 dark:bg-neutral-800">
+      {tabs.map(tab => (
+        <button
+          key={tab}
+          onClick={() => onChange(tab)}
+          className={clsx(
+            'flex items-center rounded-md px-3.5 py-1.5 transition-colors',
+            active === tab
+              ? 'bg-white shadow-xs dark:bg-neutral-700 dark:text-neutral-100'
+              : 'text-neutral-500 hover:bg-neutral-200/60 hover:text-black dark:text-neutral-400 dark:hover:bg-neutral-700/60'
+          )}
+        >
+          {tab.charAt(0).toUpperCase() + tab.slice(1)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/resources/js/pages/UserRolePermission/User/Index.tsx
+++ b/resources/js/pages/UserRolePermission/User/Index.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import DataTableWrapper, { DataTableWrapperRef } from '@/components/datatables';
 import { BreadcrumbItem } from '@/types';
 import { User } from '@/types/UserRolePermission';
-import clsx from 'clsx';
+import ToggleTabs from '@/components/toggle-tabs';
 
 const columns = (filter: string) => [
   { data: 'id', title: 'ID' },
@@ -58,7 +58,6 @@ export default function UserIndex({ filter: initialFilter, success }: { filter: 
   };
 
   const drawCallback = () => {
-    // Render tombol Edit dengan React
     document.querySelectorAll('.inertia-link-cell').forEach((cell) => {
       const id = cell.getAttribute('data-id');
       if (id) {
@@ -95,28 +94,6 @@ export default function UserIndex({ filter: initialFilter, success }: { filter: 
     });
   };
 
-  // Toggle tab menggunakan style mirip AppearanceToggleTab
-  const renderToggleTabs = () => {
-    const tabs = ['active', 'trashed', 'all'];
-    return (
-      <div className="inline-flex gap-1 rounded-lg bg-neutral-100 p-1 dark:bg-neutral-800">
-        {tabs.map((tab) => (
-          <button
-            key={tab}
-            onClick={() => setFilter(tab)}
-            className={clsx(
-              'flex items-center rounded-md px-3.5 py-1.5 transition-colors',
-              filter === tab
-                ? 'bg-white shadow-xs dark:bg-neutral-700 dark:text-neutral-100'
-                : 'text-neutral-500 hover:bg-neutral-200/60 hover:text-black dark:text-neutral-400 dark:hover:bg-neutral-700/60'
-            )}
-          >
-            {tab.charAt(0).toUpperCase() + tab.slice(1)}
-          </button>
-        ))}
-      </div>
-    );
-  };
 
   return (
     <AppLayout breadcrumbs={breadcrumbs}>
@@ -131,12 +108,12 @@ export default function UserIndex({ filter: initialFilter, success }: { filter: 
               <Button>Create User</Button>
             </Link>
           </div>
-          {/* Toggle Tabs */}
-          <div className="mb-4">{renderToggleTabs()}</div>
+
+          <ToggleTabs tabs={['active', 'trashed', 'all']} active={filter} onChange={setFilter} />
+
           {success && (
             <div className="p-2 mb-2 bg-green-100 text-green-800 rounded">{success}</div>
           )}
-          {/* Gunakan key berdasarkan filter agar DataTableWrapper re-mount ketika filter berubah */}
           <DataTableWrapper
             key={filter}
             ref={dtRef}


### PR DESCRIPTION
This pull request introduces a reusable `ToggleTabs` component and integrates it into the `UserIndex` page to replace inline tab rendering logic. The changes improve code reusability, readability, and maintainability by centralizing the tab functionality into a dedicated component.

### Component Introduction:
* Created a new `ToggleTabs` component in `resources/js/components/toggle-tabs.tsx` with props for `tabs`, `active` tab, and an `onChange` callback. The component renders a styled tab UI that supports light and dark themes.

### Integration into `UserIndex` Page:
* Replaced the inline tab rendering logic in `UserIndex` with the new `ToggleTabs` component. Updated the `renderToggleTabs` function and its usage to use this reusable component. [[1]](diffhunk://#diff-4529f865173d7844c393cbdf5b7085fad7cf29f54bf2cd8542a0c0c366a60201L98-L119) [[2]](diffhunk://#diff-4529f865173d7844c393cbdf5b7085fad7cf29f54bf2cd8542a0c0c366a60201L134-L139)
* Removed the `clsx` import from `UserIndex` as it is no longer needed after replacing the inline tab logic.

### Cleanup:
* Removed unused comments and redundant code related to the old tab rendering implementation in `UserIndex`. [[1]](diffhunk://#diff-4529f865173d7844c393cbdf5b7085fad7cf29f54bf2cd8542a0c0c366a60201L61) [[2]](diffhunk://#diff-4529f865173d7844c393cbdf5b7085fad7cf29f54bf2cd8542a0c0c366a60201L98-L119)